### PR TITLE
[mer] Convert packaging to tar_git. Contributes to MER#1706

### DIFF
--- a/rpm/libpcap.changes
+++ b/rpm/libpcap.changes
@@ -1,0 +1,5 @@
+* Thu May 22 2014 Matti Kosola <matti.kosola@jollamobile.com> - 1.5.3
+- Upgrade to latest upstream version
+
+* Fri Aug 23 2013 Matti Kosola <matti.kosola@jollamobile.com> - 1.4.0
+- Package for mer tools

--- a/rpm/libpcap.spec
+++ b/rpm/libpcap.spec
@@ -1,0 +1,79 @@
+Name: libpcap
+Version: 1.5.3
+Release: 1
+Summary: A system-independent interface for user-level packet capture
+Group: Development/Libraries
+License: BSD with advertising
+URL: http://www.tcpdump.org
+BuildRequires: bison
+BuildRequires: flex
+
+Source: %{name}-%{version}.tar.gz
+
+%description
+Libpcap provides a portable framework for low-level network
+monitoring.  Libpcap can provide network statistics collection,
+security monitoring and network debugging.  Since almost every system
+vendor provides a different interface for packet capture, the libpcap
+authors created this system-independent API to ease in porting and to
+alleviate the need for several system-dependent packet capture modules
+in each application.
+
+Install libpcap if you need to do low-level network traffic monitoring
+on your network.
+
+%package devel
+Summary: Libraries and header files for the libpcap library
+Group: Development/Libraries
+Requires: %{name} = %{version}-%{release}
+
+%description devel
+Libpcap provides a portable framework for low-level network
+monitoring.  Libpcap can provide network statistics collection,
+security monitoring and network debugging.  Since almost every system
+vendor provides a different interface for packet capture, the libpcap
+authors created this system-independent API to ease in porting and to
+alleviate the need for several system-dependent packet capture modules
+in each application.
+
+This package provides the libraries, include files, and other
+resources needed for developing libpcap applications.
+
+%prep
+# Adjusting %%setup since git-pkg unpacks to src/
+# %%setup -q
+%setup -q -n src
+
+#sparc needs -fPIC
+%ifarch %{sparc}
+sed -i -e 's|-fpic|-fPIC|g' configure
+%endif
+
+%build
+export CFLAGS="$RPM_OPT_FLAGS -fno-strict-aliasing"
+%configure
+make %{?_smp_mflags}
+
+%install
+make DESTDIR=$RPM_BUILD_ROOT install
+rm -f $RPM_BUILD_ROOT%{_libdir}/libpcap.a
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root)
+%doc LICENSE README CHANGES CREDITS
+%{_libdir}/libpcap.so.*
+%{_mandir}/man7/pcap*.7*
+
+%files devel
+%defattr(-,root,root)
+%{_bindir}/pcap-config
+%{_includedir}/pcap*.h
+%{_includedir}/pcap
+%{_libdir}/libpcap.so
+%{_mandir}/man1/pcap-config.1*
+%{_mandir}/man3/pcap*.3*
+%{_mandir}/man5/pcap*.5*


### PR DESCRIPTION
Main point to support MER#1706 is to get libpcap into mer:core. Since it wasn't there before, boss would like to see a bug number and an increase in version, so might as well convert to tar_git.